### PR TITLE
I18n : agrego internacionalización + content collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+/.astro

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,5 +7,15 @@ import mdx from "@astrojs/mdx";
 // https://astro.build/config
 export default defineConfig({
   site: "https://unicornio.dev",
-  integrations: [sitemap(), tailwind(), mdx()]
+  integrations: [sitemap(), tailwind(), mdx()],
+  i18n: {
+    defaultLocale: "es",
+    locales: ["es", "en"],
+    routing: {
+      prefixDefaultLocale: true,
+    },
+    fallback: {
+      en: "es"
+    }
+  },
 });

--- a/src/components/ui/language-picker/LanguagePicker.astro
+++ b/src/components/ui/language-picker/LanguagePicker.astro
@@ -1,0 +1,13 @@
+---
+import { languages } from "@translate/dictionary";
+
+const currentPath = Astro.url.pathname.substring(4);
+---
+
+{
+  Object.entries(languages).map(([lang, label]) => (
+    <li>
+      <a href={`/${lang}/${currentPath}`}>{label}</a>
+    </li>
+  ))
+}

--- a/src/components/ui/navbar/Navbar.astro
+++ b/src/components/ui/navbar/Navbar.astro
@@ -1,0 +1,32 @@
+---
+import { useTranslations } from "@translate/utils/utils";
+import type { Lang } from "@translate/dictionary";
+import LanguagePicker from "../language-picker/LanguagePicker.astro";
+
+const lang = Astro.currentLocale as Lang;
+const t = useTranslations(lang);
+---
+
+<ul>
+  <li>
+    <a href={`/${lang}/`}>
+      {t("nav.home")}
+    </a>
+  </li>
+  <li>
+    <a href={`/${lang}/blog/`}>
+      {t("nav.blog")}
+    </a>
+  </li>
+  <li>
+    <a href={`/${lang}/resources/`}>
+      {t("nav.resources")}
+    </a>
+  </li>
+  <li>
+    <a href={`/${lang}/about/`}>
+      {t("nav.about")}
+    </a>
+  </li>
+  <LanguagePicker />
+</ul>

--- a/src/content/blog/en/test1.md
+++ b/src/content/blog/en/test1.md
@@ -1,0 +1,12 @@
+---
+isDraft: false
+title: "Blog test 1"
+description: "Testing the new blog powered by content collections"
+publishDate: 2024-05-17
+canonicalUrl: "https://unicornio.dev/es/blog/test1"
+githubUrl: "https://github.com/florluzduarte"
+language: "en"
+tags: ["test"]
+---
+
+# Testing the new blog powered by Content Collections

--- a/src/content/blog/es/test1.md
+++ b/src/content/blog/es/test1.md
@@ -1,0 +1,12 @@
+---
+isDraft: false
+title: "Blog test 1"
+description: "Probando el blog con content collections"
+publishDate: 2024-05-17
+canonicalUrl: "https://unicornio.dev/es/blog/test1"
+githubUrl: "https://github.com/florluzduarte"
+language: "es"
+tags: ["test"]
+---
+
+# Probando el blog con Content Collections

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,42 @@
+import { z, defineCollection, reference } from "astro:content";
+
+const blogCollection = defineCollection({
+  type: "content",
+  schema: z.object({
+    isDraft: z.boolean(),
+    title: z.string(),
+    description: z.string(),
+    publishDate: z.date(),
+    canonicalUrl: z.string().url(),
+    githubUrl: z.string().url(),
+    language: z.enum(["es", "en"]),
+    tags: z.array(z.string()),
+    relatedPosts: z.array(reference("blog")).optional(),
+  })
+});
+
+const tutorialsCollection = defineCollection({
+  type: "content",
+  schema: z.object({
+    isDraft: z.boolean(),
+    title: z.string(),
+    description: z.string(),
+    publishDate: z.date(),
+    mainTech: z.string(),
+    techStack: z.array(z.string()),
+    status: z.enum(["completed", "ongoing"]),
+    canonicalUrl: z.string().url(),
+    githubUrl: z.string().url(),
+    language: z.enum(["es", "en"]),
+    image: z.object({
+      src: z.string(),
+      alt: z.string(),
+    }),
+    relatedTutorials: z.array(reference("tutorials")).optional(),
+  })
+});
+
+export const collections = {
+  "blog": blogCollection,
+  "tutorials": tutorialsCollection,
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />

--- a/src/i18n/dictionary.ts
+++ b/src/i18n/dictionary.ts
@@ -1,0 +1,23 @@
+export const languages = {
+  en: "English",
+  es: "Español",
+};
+
+export type Lang = "es" | "en";
+
+export const defaultLang = "es";
+
+export const dictionary = {
+  es: {
+    "nav.home": "Inicio",
+    "nav.blog": "Blog",
+    "nav.resources": "Recursos",
+    "nav.about": "Acerca",
+  },
+  en: {
+    "nav.home": "Home",
+    "nav.blog": "Blog",
+    "nav.resources": "Resources",
+    "nav.about": "About",
+  }
+} as const;

--- a/src/i18n/utils/utils.ts
+++ b/src/i18n/utils/utils.ts
@@ -1,0 +1,7 @@
+import { dictionary, defaultLang } from "../dictionary";
+
+export function useTranslations(lang: keyof typeof dictionary) {
+  return function t(key: keyof typeof dictionary[typeof defaultLang]) {
+    return dictionary[lang][key] || dictionary[defaultLang][key];
+  }
+};

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,10 +14,12 @@ const {
 } = Astro.props;
 
 const urlFinal = `https://unicornio.dev${urlPath}`;
+
+const locale = Astro.currentLocale;
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={locale}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,6 @@
 ---
+import Navbar from "@components/ui/navbar/Navbar.astro";
+
 export interface Props {
   title?: string;
   description?: string;
@@ -46,6 +48,7 @@ const locale = Astro.currentLocale;
     <meta property="twitter:image" content={image} />
   </head>
   <body class="bg-black text-white min-h-screen">
+    <Navbar />
     <main
       class="flex flex-col gap-14 mt-14 lg:mt-24 mx-6 md:max-w-2xl md:mx-auto lg:max-w-3xl xl:max-w-5xl"
     >

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { ViewTransitions } from "astro:transitions";
 import Navbar from "@components/ui/navbar/Navbar.astro";
 
 export interface Props {
@@ -46,6 +47,8 @@ const locale = Astro.currentLocale;
     <meta property="twitter:title" content={title} />
     <meta property="twitter:description" content={description} />
     <meta property="twitter:image" content={image} />
+
+    <ViewTransitions />
   </head>
   <body class="bg-black text-white min-h-screen">
     <Navbar />

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -3,7 +3,6 @@ import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
   const pages = await getCollection("blog");
-  console.log(pages);
   const paths = pages.map((page: any) => {
     const [lang, ...slug] = page.slug.split("/");
     return {

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -1,0 +1,29 @@
+---
+import { getCollection } from "astro:content";
+
+export async function getStaticPaths() {
+  const pages = await getCollection("blog");
+  console.log(pages);
+  const paths = pages.map((page: any) => {
+    const [lang, ...slug] = page.slug.split("/");
+    return {
+      params: {
+        lang: lang,
+        slug: slug.join("/") || undefined,
+      },
+      props: page,
+    };
+  });
+  return paths;
+}
+
+const { lang, slug } = Astro.params;
+const page = Astro.props;
+const formatDate = page.data.publishDate.toLocaleString(lang).split(",");
+const formattedDateByLang = formatDate[0];
+const { Content } = await page.render();
+---
+
+<h1>{page.data.title}</h1>
+<p>{formattedDateByLang}</p>
+<Content />

--- a/src/pages/en/about.astro
+++ b/src/pages/en/about.astro
@@ -1,0 +1,7 @@
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+---
+
+<BaseLayout>
+  <h1>About me in english</h1>
+</BaseLayout>

--- a/src/pages/en/blog.astro
+++ b/src/pages/en/blog.astro
@@ -1,0 +1,7 @@
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+---
+
+<BaseLayout>
+  <h1>Blog in english</h1>
+</BaseLayout>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,0 +1,7 @@
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+---
+
+<BaseLayout>
+  <h1>Mishins Diaz Duarte</h1>
+</BaseLayout>

--- a/src/pages/en/resources.astro
+++ b/src/pages/en/resources.astro
@@ -1,0 +1,7 @@
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+---
+
+<BaseLayout>
+  <h1>Resources page</h1>
+</BaseLayout>

--- a/src/pages/es/about.astro
+++ b/src/pages/es/about.astro
@@ -1,0 +1,7 @@
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+---
+
+<BaseLayout>
+  <h1>Sobre mi en español</h1>
+</BaseLayout>

--- a/src/pages/es/blog.astro
+++ b/src/pages/es/blog.astro
@@ -1,0 +1,7 @@
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+---
+
+<BaseLayout>
+  <h1>Blog en español</h1>
+</BaseLayout>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -1,0 +1,7 @@
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+---
+
+<BaseLayout>
+  <h1 class="text-pink-400 font-bold">Flor Luz Duarte</h1>
+</BaseLayout>

--- a/src/pages/es/resources.astro
+++ b/src/pages/es/resources.astro
@@ -1,0 +1,7 @@
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+---
+
+<BaseLayout>
+  <h1>Recursos en español</h1>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,0 @@
----
-import BaseLayout from "@layouts/BaseLayout.astro";
----
-
-<BaseLayout>
-  <h1 class="text-pink-400">Flor Luz Duarte</h1>
-</BaseLayout>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
       "@assets/*": ["src/assets/*"],
       "@layouts/*": ["src/layouts/*"],
       "@data/*": ["src/data/*"],
+      "@translate/*": ["src/i18n/*"],
     }
   }
 }


### PR DESCRIPTION
- Configuraciones iniciales para i18n nativo de Astro
- Configuraciones para generar un blog a partir de Content collections
- Se agregan Navbar y LanguagePicker componentes para más pruebas de i18n (wip)
- Se agregan dentro de la carperta i18n: dictionary y useTranslations utils
- Se agregan ViewTransitions en el BaseLayout